### PR TITLE
WIP - Adaptive Scaling on SGE

### DIFF
--- a/Dockerfile-master
+++ b/Dockerfile-master
@@ -7,9 +7,7 @@ RUN apt-get update && apt-get install curl bzip2 git -y --fix-missing
 RUN curl -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 RUN bash miniconda.sh -f -b -p /opt/anaconda
 ENV PATH /opt/anaconda/bin:$PATH
-RUN conda install dask distributed drmaa nomkl pytest mock ipython pip psutil
-RUN pip install git+https://github.com/dask/dask.git --upgrade
-RUN pip install git+https://github.com/dask/distributed.git --upgrade
+RUN conda install -c conda-forge dask distributed drmaa nomkl pytest mock ipython pip psutil 
 
 COPY ./*.sh /
 COPY ./*.txt /

--- a/Dockerfile-master
+++ b/Dockerfile-master
@@ -3,11 +3,14 @@ FROM ubuntu:14.04
 ENV LANG C.UTF-8
 
 RUN apt-get update && apt-get install curl bzip2 git -y --fix-missing
+
 RUN curl -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 RUN bash miniconda.sh -f -b -p /opt/anaconda
 ENV PATH /opt/anaconda/bin:$PATH
-RUN conda install dask distributed drmaa nomkl pytest mock ipython pip
-RUN pip install git+https://github.com/dask/dask.git git+https://github.com/dask/dask.git --upgrade
+RUN conda install dask distributed drmaa nomkl pytest mock ipython pip psutil
+RUN pip install git+https://github.com/dask/dask.git --upgrade
+RUN pip install git+https://github.com/dask/distributed.git --upgrade
+
 COPY ./*.sh /
 COPY ./*.txt /
 RUN bash ./setup-master.sh

--- a/Dockerfile-master
+++ b/Dockerfile-master
@@ -2,12 +2,12 @@ FROM ubuntu:14.04
 
 ENV LANG C.UTF-8
 
-RUN apt-get update
-RUN apt-get install curl bzip2 -y
+RUN apt-get update && apt-get install curl bzip2 git -y --fix-missing
 RUN curl -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 RUN bash miniconda.sh -f -b -p /opt/anaconda
 ENV PATH /opt/anaconda/bin:$PATH
-RUN conda install dask distributed drmaa nomkl pytest mock ipython
+RUN conda install dask distributed drmaa nomkl pytest mock ipython pip
+RUN pip install git+https://github.com/dask/dask.git git+https://github.com/dask/dask.git --upgrade
 COPY ./*.sh /
 COPY ./*.txt /
 RUN bash ./setup-master.sh

--- a/Dockerfile-master
+++ b/Dockerfile-master
@@ -2,12 +2,13 @@ FROM ubuntu:14.04
 
 ENV LANG C.UTF-8
 
-RUN apt-get update && apt-get install curl bzip2 git -y --fix-missing
+RUN apt-get update && apt-get install curl bzip2 git gcc -y --fix-missing
 
 RUN curl -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 RUN bash miniconda.sh -f -b -p /opt/anaconda
 ENV PATH /opt/anaconda/bin:$PATH
 RUN conda install -c conda-forge dask distributed drmaa nomkl pytest mock ipython pip psutil 
+RUN pip install git+https://github.com/dask/distributed.git --upgrade
 
 COPY ./*.sh /
 COPY ./*.txt /

--- a/Dockerfile-slave
+++ b/Dockerfile-slave
@@ -7,8 +7,10 @@ RUN apt-get update && apt-get install curl bzip2 git -y --fix-missing
 RUN curl -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 RUN bash miniconda.sh -f -b -p /opt/anaconda
 ENV PATH /opt/anaconda/bin:$PATH
-RUN conda install dask distributed drmaa nomkl pytest mock pip
-RUN pip install git+https://github.com/dask/dask.git git+https://github.com/dask/dask.git --upgrade
+RUN conda install dask distributed drmaa nomkl pytest mock ipython pip psutil
+RUN pip install git+https://github.com/dask/dask.git --upgrade
+RUN pip install git+https://github.com/dask/distributed.git --upgrade
+
 COPY ./setup-slave.sh /
 COPY ./run-slave.sh /
 RUN bash ./setup-slave.sh

--- a/Dockerfile-slave
+++ b/Dockerfile-slave
@@ -2,12 +2,13 @@ FROM ubuntu:14.04
 
 ENV LANG C.UTF-8
 
-RUN apt-get update
-RUN apt-get install curl bzip2 -y
+RUN apt-get update && apt-get install curl bzip2 git -y --fix-missing
+
 RUN curl -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 RUN bash miniconda.sh -f -b -p /opt/anaconda
 ENV PATH /opt/anaconda/bin:$PATH
-RUN conda install dask distributed drmaa nomkl pytest mock
+RUN conda install dask distributed drmaa nomkl pytest mock pip
+RUN pip install git+https://github.com/dask/dask.git git+https://github.com/dask/dask.git --upgrade
 COPY ./setup-slave.sh /
 COPY ./run-slave.sh /
 RUN bash ./setup-slave.sh

--- a/Dockerfile-slave
+++ b/Dockerfile-slave
@@ -2,12 +2,13 @@ FROM ubuntu:14.04
 
 ENV LANG C.UTF-8
 
-RUN apt-get update && apt-get install curl bzip2 git -y --fix-missing
+RUN apt-get update && apt-get install curl bzip2 git gcc -y --fix-missing
 
 RUN curl -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 RUN bash miniconda.sh -f -b -p /opt/anaconda
 ENV PATH /opt/anaconda/bin:$PATH
-RUN conda install dask distributed drmaa nomkl pytest mock ipython pip psutil -c conda-forge
+RUN conda install -c conda-forge dask distributed drmaa nomkl pytest mock ipython pip psutil 
+RUN pip install git+https://github.com/dask/distributed.git --upgrade
 
 COPY ./setup-slave.sh /
 COPY ./run-slave.sh /

--- a/Dockerfile-slave
+++ b/Dockerfile-slave
@@ -7,9 +7,7 @@ RUN apt-get update && apt-get install curl bzip2 git -y --fix-missing
 RUN curl -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 RUN bash miniconda.sh -f -b -p /opt/anaconda
 ENV PATH /opt/anaconda/bin:$PATH
-RUN conda install dask distributed drmaa nomkl pytest mock ipython pip psutil
-RUN pip install git+https://github.com/dask/dask.git --upgrade
-RUN pip install git+https://github.com/dask/distributed.git --upgrade
+RUN conda install dask distributed drmaa nomkl pytest mock ipython pip psutil -c conda-forge
 
 COPY ./setup-slave.sh /
 COPY ./run-slave.sh /

--- a/add_worker.sh
+++ b/add_worker.sh
@@ -18,6 +18,9 @@ qconf -aattr hostgroup hostlist $HOSTNAME @allhosts
 # enable the host for the queue, in case it was disabled and not removed
 qmod -e $QUEUE@$HOSTNAME
 
+# Add memory resource
+qconf -mattr exechost complex_values h_vmem=100G $HOSTNAME
+
 if [ "$SLOTS" ]; then
     qconf -aattr queue slots "[$HOSTNAME=$SLOTS]" $QUEUE
 fi

--- a/dask_drmaa/__init__.py
+++ b/dask_drmaa/__init__.py
@@ -1,1 +1,2 @@
-from .core import DRMAACluster, SGECluster
+from .core import DRMAACluster
+from .sge import SGECluster

--- a/dask_drmaa/adaptive.py
+++ b/dask_drmaa/adaptive.py
@@ -48,7 +48,8 @@ class Adaptive(object):
 
             if workers:
                 logger.info("Retiring workers %s", workers)
-                f = self.cluster.scale_down(workers)
+                ids = [self.scheduler.worker_info[w]['name'] for w in workers]
+                f = self.cluster.stop_workers(ids)
                 if gen.is_future(f):
                     yield f
 
@@ -73,7 +74,7 @@ class Adaptive(object):
                     logger.info("Starting worker")
                     self.cluster.start_workers(1, memory=memory * 2)
 
-                # yield self._retire_workers()
+                yield self._retire_workers()
             finally:
                 self._adapting = False
 

--- a/dask_drmaa/adaptive.py
+++ b/dask_drmaa/adaptive.py
@@ -1,0 +1,81 @@
+from __future__ import print_function, division, absolute_import
+
+import logging
+from distributed.utils import log_errors
+
+from toolz import first
+from tornado import gen
+from tornado.ioloop import PeriodicCallback
+
+logger = logging.getLogger(__file__)
+
+
+class Adaptive(object):
+    '''
+    Adaptively allocate workers based on scheduler load.  A superclass.
+
+    Contains logic to dynamically resize a Dask cluster based on current use.
+
+    Parameters
+    ----------
+    scheduler: distributed.Scheduler
+    cluster: object
+        Must have scale_up and scale_down methods/coroutines
+
+    Examples
+    --------
+    >>> class MyCluster(object):
+    ...     def scale_up(self, n):
+    ...         """ Bring worker count up to n """
+    ...     def scale_down(self, workers):
+    ...        """ Remove worker addresses from cluster """
+    '''
+    def __init__(self, scheduler=None, cluster=None, interval=1000, startup_cost=1):
+        self.cluster = cluster
+        if scheduler is None:
+            scheduler = cluster.scheduler
+        self.scheduler = scheduler
+        self.startup_cost = startup_cost
+        self._adapt_callback = PeriodicCallback(self._adapt, interval,
+                                                self.scheduler.loop)
+        self.scheduler.loop.add_callback(self._adapt_callback.start)
+        self._adapting = False
+
+    @gen.coroutine
+    def _retire_workers(self):
+        with log_errors():
+            workers = yield self.scheduler.retire_workers(remove=False)
+
+            if workers:
+                logger.info("Retiring workers %s", workers)
+                f = self.cluster.scale_down(workers)
+                if gen.is_future(f):
+                    yield f
+
+                for w in workers:
+                    self.scheduler.remove_worker(address=w, safe=True)
+
+    @gen.coroutine
+    def _adapt(self):
+        logger.info("Adapting")
+        with log_errors():
+            if self._adapting:  # Semaphore to avoid overlapping adapt calls
+                return
+
+            s = self.scheduler
+
+            self._adapting = True
+            try:
+                if s.unrunnable:
+                    key = first(s.unrunnable)
+                    memory = s.resource_restrictions[key]['memory']
+
+                    logger.info("Starting worker")
+                    self.cluster.start_workers(1, memory=memory * 2)
+
+                # yield self._retire_workers()
+            finally:
+                self._adapting = False
+
+    def adapt(self):
+        self.scheduler.loop.add_callback(self._adapt)

--- a/dask_drmaa/adaptive.py
+++ b/dask_drmaa/adaptive.py
@@ -7,6 +7,8 @@ from toolz import first
 from tornado import gen
 from tornado.ioloop import PeriodicCallback
 
+from .core import get_session
+
 logger = logging.getLogger(__file__)
 
 
@@ -68,7 +70,7 @@ class Adaptive(object):
                     #  We need a worker with more resources. See if one has already been requested.
                     for worker, resources in self.cluster.workers.items():
                         if (resources.get("memory", 0) >= memory * 2 and
-                            self.cluster.session.jobStatus(worker) in ('running', 'queued_active')):
+                            get_session().jobStatus(worker) in ('running', 'queued_active')):
                                 #There is already an existing valid worker requested with the necessary
                                 #  resources to run this task. If the worker has any other status (like DONE, HOLD, etc.), scheduler another task.
                                 break

--- a/dask_drmaa/adaptive.py
+++ b/dask_drmaa/adaptive.py
@@ -42,10 +42,11 @@ class Adaptive(object):
 
     @gen.coroutine
     def _retire_workers(self):
-        """Get the cluster scheduler to cleanup any workers it decides can retire
+        """
+        Get the cluster scheduler to cleanup any workers it decides can retire
         """
         with log_errors():
-            workers = yield self.scheduler.retire_workers(remove=True)
+            workers = yield self.scheduler.retire_workers(remove=True, close=True)
             logger.info("Retiring workers {}".format(workers))
 
     @gen.coroutine
@@ -63,10 +64,10 @@ class Adaptive(object):
                     key = first(s.unrunnable)
                     memory = s.resource_restrictions[key]['memory']
 
-                    #We need a worker with more resources. See if one has already been requested.
+                    #  We need a worker with more resources. See if one has already been requested.
                     for worker, resources in self.cluster.workers.items():
                         if (resources.get("memory", 0) >= memory * 2 and
-                            self.cluster.jobStatus(worker) in ('running', 'queued_active')):
+                            self.cluster.session.jobStatus(worker) in ('running', 'queued_active')):
                                 #There is already an existing valid worker requested with the necessary
                                 #  resources to run this task. If the worker has any other status (like DONE, HOLD, etc.), scheduler another task.
                                 break

--- a/dask_drmaa/adaptive.py
+++ b/dask_drmaa/adaptive.py
@@ -9,6 +9,7 @@ from tornado.ioloop import PeriodicCallback
 
 logger = logging.getLogger(__file__)
 
+
 class Adaptive(object):
     '''
     Adaptively allocate workers based on scheduler load.  A superclass.

--- a/dask_drmaa/core.py
+++ b/dask_drmaa/core.py
@@ -117,6 +117,7 @@ class SGECluster(DRMAACluster):
         if cpus:
             args = args + ['--nprocs', '1', '--nthreads', str(cpus)]
             # ns += ' -l TODO=%d' % (cpu + 1)
+        args = args + ['--name', '$PBS_JOBID']
 
         wt = self.session.createJobTemplate()
         wt.jobName = self.jobName

--- a/dask_drmaa/core.py
+++ b/dask_drmaa/core.py
@@ -117,7 +117,6 @@ class SGECluster(DRMAACluster):
         if cpus:
             args = args + ['--nprocs', '1', '--nthreads', str(cpus)]
             # ns += ' -l TODO=%d' % (cpu + 1)
-        args = args + ['--name', '$PBS_JOBID']
 
         wt = self.session.createJobTemplate()
         wt.jobName = self.jobName

--- a/dask_drmaa/core.py
+++ b/dask_drmaa/core.py
@@ -109,8 +109,8 @@ class SGECluster(DRMAACluster):
         if nativeSpecification:
             ns = ns + nativeSpecification
         if memory:
-            args = args + ['--memory-limit', str(memory * 1e9 * 0.6)]
-            ns += ' -l h_vmem=%dG' % memory  # / cpus
+            args = args + ['--memory-limit', str(memory * 0.6)]
+            ns += ' -l h_vmem=%dG' % int(memory / 1e9) # / cpus
         if cpus:
             args = args + ['--nprocs', '1', '--nthreads', str(cpus)]
             # ns += ' -l TODO=%d' % (cpu + 1)

--- a/dask_drmaa/core.py
+++ b/dask_drmaa/core.py
@@ -105,13 +105,19 @@ class DRMAACluster(object):
 
 
 class SGECluster(DRMAACluster):
-    def createJobTemplate(self, nativeSpecification='', cpus=1, memory=None):
+    default_memory = None
+    default_memory_fraction = 0.6
+    def createJobTemplate(self, nativeSpecification='', cpus=1, memory=None,
+            memory_fraction=None):
+        memory = memory or self.default_memory
+        memory_fraction = memory_fraction or self.default_memory_fraction
+
         args = self.args
         ns = self.nativeSpecification
         if nativeSpecification:
             ns = ns + nativeSpecification
         if memory:
-            args = args + ['--memory-limit', str(memory * 0.6)]
+            args = args + ['--memory-limit', str(memory * memory_fraction)]
             args = args + ['--resources', 'memory=%f' % (memory * 0.8)]
             ns += ' -l h_vmem=%dG' % int(memory / 1e9) # / cpus
         if cpus:

--- a/dask_drmaa/core.py
+++ b/dask_drmaa/core.py
@@ -35,6 +35,8 @@ class DRMAACluster(object):
         self.errorPath = errorPath
         self.nativeSpecification = nativeSpecification
 
+        #maps cluster job ids to the resources requested in the job
+        #e.g. {'15.3': {'memory': 9gb, 'cpus': 4}}
         self.workers = {}
 
     @property

--- a/dask_drmaa/core.py
+++ b/dask_drmaa/core.py
@@ -24,7 +24,7 @@ class DRMAACluster(object):
         """
         Parameters
         ----------
-        jobName: string name of the job as known by the DRMAA cluster. 
+        jobName: string name of the job as known by the DRMAA cluster.
                  For an SGE cluster, this can be seen with the "qstat" command.
         remoteCommand: The path to the executable that this cluster should execute in a job by default
         args: an iterable of arguments for the remoteCommand application
@@ -49,14 +49,7 @@ class DRMAACluster(object):
         self.nativeSpecification = nativeSpecification
         self.max_runtime = max_runtime
 
-        #maps cluster job ids to the resources requested in the job
-        #e.g. {'15.3': {'memory': 9gb, 'cpus': 4}}
-        self.workers = {}
-
-        #The worker cleanup time should be fairly easy to configure
-        #Sometimes, we only want to cleanup a worker that has been idle
-        # for at least 30 minutes.
-        #Other times, we should cleanup the worker after 1 minute.
+        self.workers = {}  # {job-id: {'resource': quanitty}}
 
     @property
     def scheduler(self):

--- a/dask_drmaa/sge.py
+++ b/dask_drmaa/sge.py
@@ -1,0 +1,34 @@
+from .core import DRMAACluster, get_session
+
+
+class SGECluster(DRMAACluster):
+    default_memory = None
+    default_memory_fraction = 0.6
+    def createJobTemplate(self, nativeSpecification='', cpus=1, memory=None,
+            memory_fraction=None):
+        memory = memory or self.default_memory
+        memory_fraction = memory_fraction or self.default_memory_fraction
+
+        args = self.args
+        ns = self.nativeSpecification
+        if nativeSpecification:
+            ns = ns + nativeSpecification
+        if memory:
+            args = args + ['--memory-limit', str(memory * memory_fraction)]
+            args = args + ['--resources', 'memory=%f' % (memory * 0.8)]
+            ns += ' -l h_vmem=%dG' % int(memory / 1e9) # / cpus
+        if cpus:
+            args = args + ['--nprocs', '1', '--nthreads', str(cpus)]
+            # ns += ' -l TODO=%d' % (cpu + 1)
+
+        ns += ' -l h_rt={}'.format(self.max_runtime)
+
+        wt = get_session().createJobTemplate()
+        wt.jobName = self.jobName
+        wt.remoteCommand = self.remoteCommand
+        wt.args = args
+        wt.outputPath = self.outputPath
+        wt.errorPath = self.errorPath
+        wt.nativeSpecification = ns
+
+        return wt

--- a/dask_drmaa/tests/test_adaptive.py
+++ b/dask_drmaa/tests/test_adaptive.py
@@ -1,0 +1,16 @@
+from dask_drmaa import SGECluster
+from dask_drmaa.adaptive import Adaptive
+from distributed import Client
+from distributed.utils_test import loop, inc
+
+from time import sleep
+
+def test_adaptive_memory(loop):
+    with SGECluster(scheduler_port=0) as cluster:
+        adapt = Adaptive(cluster=cluster)
+        with Client(cluster, loop=loop) as client:
+            future = client.submit(inc, 1, resources={'memory': 1e9})
+            assert future.result() == 2
+            assert len(cluster.scheduler.ncores) > 0
+            r = list(cluster.scheduler.worker_resources.values())[0]
+            assert r['memory'] > 1e9

--- a/dask_drmaa/tests/test_adaptive.py
+++ b/dask_drmaa/tests/test_adaptive.py
@@ -3,7 +3,7 @@ from dask_drmaa.adaptive import Adaptive
 from distributed import Client
 from distributed.utils_test import loop, inc
 
-from time import sleep
+from time import sleep, time
 
 def test_adaptive_memory(loop):
     with SGECluster(scheduler_port=0) as cluster:
@@ -14,3 +14,10 @@ def test_adaptive_memory(loop):
             assert len(cluster.scheduler.ncores) > 0
             r = list(cluster.scheduler.worker_resources.values())[0]
             assert r['memory'] > 1e9
+
+            del future
+
+            start = time()
+            while cluster.workers:
+                sleep(0.1)
+                assert time() < start + 10

--- a/dask_drmaa/tests/test_adaptive.py
+++ b/dask_drmaa/tests/test_adaptive.py
@@ -1,9 +1,12 @@
+from time import sleep, time
+
+import pytest
+
 from dask_drmaa import SGECluster
 from dask_drmaa.adaptive import Adaptive
 from distributed import Client
 from distributed.utils_test import loop, inc
 
-from time import sleep, time
 
 def test_adaptive_memory(loop):
     with SGECluster(scheduler_port=0) as cluster:
@@ -17,40 +20,14 @@ def test_adaptive_memory(loop):
 
             del future
 
-            """
+            start = time()
+            while client.ncores():
+                sleep(0.3)
+                assert time() < start + 10
+
+            """ # TODO: jobs aren't shutting down when process ends
             start = time()
             while cluster.workers:
                 sleep(0.1)
-                assert time() < start + 10
+                assert time() < start + 60
             """
-
-def test_sge_adaptive_worker_cleanup(loop):
-    """Test that cluster workers are cleaned up after an appropriate 
-         waiting time. In this case, SGE will clean things up after 20 seconds.
-    """
-    def long_running_func(time, num):
-        sleep(time)
-        return num + 1
-    
-    with SGECluster(scheduler_port=0, max_runtime='0:0:15') as cluster:
-        adapt = Adaptive(cluster=cluster)
-        with Client(cluster, loop=loop) as client:
-            future = client.submit(long_running_func, 5, 3, resources={'memory': 1e9})
-            while future.status == 'pending':
-                sleep(1)
-                
-            running_workers = [jid for jid in cluster.workers if cluster.jobStatus(jid) in ("running", "queued_active")]
-            assert len(running_workers) > 0
-            assert future.result() == 4
-            
-            start = time()
-            #If the workers are done, ignore them. The scheduler
-            #  might keep a record of them around for a while in case someone
-            #  wants to check on them.
-            while running_workers:
-                print(running_workers)
-                sleep(1)
-                assert time() < start + 30
-                running_workers = [jid for jid in cluster.workers if cluster.jobStatus(jid) in ("running", "queued_active")]
-
-            del future

--- a/dask_drmaa/tests/test_adaptive.py
+++ b/dask_drmaa/tests/test_adaptive.py
@@ -17,7 +17,9 @@ def test_adaptive_memory(loop):
 
             del future
 
+            """
             start = time()
             while cluster.workers:
                 sleep(0.1)
                 assert time() < start + 10
+            """

--- a/dask_drmaa/tests/test_core.py
+++ b/dask_drmaa/tests/test_core.py
@@ -34,7 +34,7 @@ def test_str(loop):
 
 def test_sge_memory(loop):
     with SGECluster(scheduler_port=0) as cluster:
-        cluster.start_workers(2, memory=2)
+        cluster.start_workers(2, memory=2e9)
         with Client(cluster, loop=loop) as client:
             while len(cluster.scheduler.ncores) < 2:
                 sleep(0.1)

--- a/dask_drmaa/tests/test_core.py
+++ b/dask_drmaa/tests/test_core.py
@@ -34,12 +34,12 @@ def test_str(loop):
 
 def test_sge_memory(loop):
     with SGECluster(scheduler_port=0) as cluster:
-        cluster.start_workers(2, memory=1e9)
+        cluster.start_workers(2, memory=3e9, memory_fraction=0.5)
         with Client(cluster, loop=loop) as client:
             while len(cluster.scheduler.ncores) < 2:
                 sleep(0.1)
 
-            assert all(500e6 < info['memory_limit'] < 1e9
+            assert all(info['memory_limit'] == 1.5e9
                        for info in cluster.scheduler.worker_info.values())
 
 

--- a/dask_drmaa/tests/test_core.py
+++ b/dask_drmaa/tests/test_core.py
@@ -40,11 +40,10 @@ def test_job_name_as_name(loop):
         cluster.start_workers(2)
         while len(cluster.scheduler.workers) < 1:
             sleep(0.1)
-            names = [cluster.scheduler.worker_info[w]['name']
-                     for w in cluster.scheduler.workers]
+            names = {cluster.scheduler.worker_info[w]['name']
+                     for w in cluster.scheduler.workers}
 
-            assert all('job' not in name.lower() for name in names)
-            assert all('drmaa' not in name.lower() for name in names)
+            assert names == set(cluster.workers)
 
 
 def test_multiple_overlapping_clusters(loop):

--- a/dask_drmaa/tests/test_core.py
+++ b/dask_drmaa/tests/test_core.py
@@ -34,12 +34,12 @@ def test_str(loop):
 
 def test_sge_memory(loop):
     with SGECluster(scheduler_port=0) as cluster:
-        cluster.start_workers(2, memory=2e9)
+        cluster.start_workers(2, memory=1e9)
         with Client(cluster, loop=loop) as client:
             while len(cluster.scheduler.ncores) < 2:
                 sleep(0.1)
 
-            assert all(1e9 < info['memory_limit'] < 2e9
+            assert all(500e6 < info['memory_limit'] < 1e9
                        for info in cluster.scheduler.worker_info.values())
 
 

--- a/dask_drmaa/tests/test_core.py
+++ b/dask_drmaa/tests/test_core.py
@@ -2,7 +2,7 @@ from time import sleep, time
 
 import pytest
 
-from dask_drmaa import DRMAACluster, SGECluster
+from dask_drmaa import DRMAACluster
 from distributed import Client
 from distributed.utils_test import loop, inc
 
@@ -32,27 +32,6 @@ def test_str(loop):
         assert '2' in str(cluster)
         assert '2' in repr(cluster)
         1 + 1
-
-
-def test_sge_memory(loop):
-    with SGECluster(scheduler_port=0) as cluster:
-        cluster.start_workers(2, memory=3e9, memory_fraction=0.5)
-        with Client(cluster, loop=loop) as client:
-            while len(cluster.scheduler.ncores) < 2:
-                sleep(0.1)
-
-            assert all(info['memory_limit'] == 1.5e9
-                       for info in cluster.scheduler.worker_info.values())
-
-
-def test_sge_cpus(loop):
-    with SGECluster(scheduler_port=0) as cluster:
-        cluster.start_workers(1, cpus=2)
-        with Client(cluster, loop=loop) as client:
-            while len(cluster.scheduler.ncores) < 1:
-                sleep(0.1)
-
-            assert list(cluster.scheduler.ncores.values()) == [2]
 
 
 @pytest.mark.xfail(reason="Can't use job name environment variable as arg")

--- a/dask_drmaa/tests/test_sge.py
+++ b/dask_drmaa/tests/test_sge.py
@@ -1,0 +1,27 @@
+from time import sleep
+
+import pytest
+
+from dask_drmaa import SGECluster
+from distributed import Client
+from distributed.utils_test import loop
+
+def test_sge_memory(loop):
+    with SGECluster(scheduler_port=0) as cluster:
+        cluster.start_workers(2, memory=3e9, memory_fraction=0.5)
+        with Client(cluster, loop=loop) as client:
+            while len(cluster.scheduler.ncores) < 2:
+                sleep(0.1)
+
+            assert all(info['memory_limit'] == 1.5e9
+                       for info in cluster.scheduler.worker_info.values())
+
+
+def test_sge_cpus(loop):
+    with SGECluster(scheduler_port=0) as cluster:
+        cluster.start_workers(1, cpus=2)
+        with Client(cluster, loop=loop) as client:
+            while len(cluster.scheduler.ncores) < 1:
+                sleep(0.1)
+
+            assert list(cluster.scheduler.ncores.values()) == [2]


### PR DESCRIPTION
This adds a very dumb `Adaptive` cluster class (stolen from `distributed.deploy.adaptive`) that looks at tasks running on the scheduler and uses the stated resources to inform SGECluster worker requests.

The current policy is unsophisticated.  If there are unrunnable tasks then it launches a worker with more memory than is required by the first task.  Ideally we would want to scale out in some proportional way, or look at many unrunnable tasks, etc..  

Additionally there is currently no scale down mechanism.  The easiest way to get this to work is to inform the workers of their job id to allow the scheduler to map backwards from worker to SGE task to kill.  A bit of google searching revealed that the environment variable `$JOB_ID` or `$PBS_JOBID` should be set, unfortunately this doesn't appear to work on first attempt.  See failing test in https://github.com/dask/dask-drmaa/commit/dd8d1bcedc0ea923a830321ffc751dbf07b3bc35  (help appreciated)

What's here is clearly insufficient, but I think it lays sufficient groundwork so that eventual solutions become clear.