### PR TITLE
Enable adaptive to close workers

### DIFF
--- a/dask_drmaa/__init__.py
+++ b/dask_drmaa/__init__.py
@@ -1,2 +1,2 @@
-from .core import DRMAACluster
+from .core import DRMAACluster, get_session
 from .sge import SGECluster

--- a/dask_drmaa/adaptive.py
+++ b/dask_drmaa/adaptive.py
@@ -50,7 +50,7 @@ class Adaptive(object):
         Get the cluster scheduler to cleanup any workers it decides can retire
         """
         with log_errors():
-            workers = yield self.scheduler.retire_workers(remove=True, close=True)
+            workers = yield self.scheduler.retire_workers(close=True)
             logger.info("Retiring workers {}".format(workers))
 
     @gen.coroutine

--- a/dask_drmaa/tests/test_adaptive.py
+++ b/dask_drmaa/tests/test_adaptive.py
@@ -10,7 +10,7 @@ from distributed.utils_test import loop, inc, slowinc
 
 
 def test_adaptive_memory(loop):
-    with SGECluster(scheduler_port=0) as cluster:
+    with SGECluster(scheduler_port=0, cleanup_interval=100) as cluster:
         adapt = Adaptive(cluster=cluster)
         with Client(cluster, loop=loop) as client:
             future = client.submit(inc, 1, resources={'memory': 1e9})
@@ -26,12 +26,10 @@ def test_adaptive_memory(loop):
                 sleep(0.3)
                 assert time() < start + 10
 
-            """ # TODO: jobs aren't shutting down when process endst
             start = time()
             while cluster.workers:
                 sleep(0.1)
-                assert time() < start + 60
-            """
+                assert time() < start + 10
 
 
 def test_adaptive_normal_tasks(loop):


### PR DESCRIPTION
Previously this failed due to issues with dask/distributed.
Those have since been resolved.  We are now able to close workers
from the scheduler and clean up the drmaa jobs accordingly.