### PR TITLE
Clean up all lingering workers at exit

### DIFF
--- a/dask_drmaa/__init__.py
+++ b/dask_drmaa/__init__.py
@@ -1,2 +1,3 @@
 from .core import DRMAACluster, get_session
 from .sge import SGECluster
+from .adaptive import Adaptive


### PR DESCRIPTION
This helps to robustly clean up workers if the user does not clean up well.