### PR TITLE
Use bash script rather than dask-worker executable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
 
 script:
   - docker exec -it sge_master /bin/bash -c "cd /dask-drmaa; python setup.py install"
-  - docker exec -it sge_master py.test dask-drmaa/dask_drmaa --verbose
+  - docker exec -it sge_master /bin/bash -c "cd /dask-drmaa; py.test dask_drmaa --verbose"
 
 after_success:
   - docker exec -it sge_master bash -c 'cat /tmp/sge*'

--- a/Dockerfile-master
+++ b/Dockerfile-master
@@ -7,7 +7,8 @@ RUN apt-get update && apt-get install curl bzip2 git gcc -y --fix-missing
 RUN curl -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 RUN bash miniconda.sh -f -b -p /opt/anaconda
 ENV PATH /opt/anaconda/bin:$PATH
-RUN conda install -c conda-forge dask distributed drmaa nomkl pytest mock ipython pip psutil 
+RUN conda install -c conda-forge dask distributed nomkl pytest mock ipython pip psutil
+RUN pip install drmaa
 RUN pip install git+https://github.com/dask/distributed.git --upgrade
 
 COPY ./*.sh /

--- a/Dockerfile-slave
+++ b/Dockerfile-slave
@@ -7,7 +7,8 @@ RUN apt-get update && apt-get install curl bzip2 git gcc -y --fix-missing
 RUN curl -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 RUN bash miniconda.sh -f -b -p /opt/anaconda
 ENV PATH /opt/anaconda/bin:$PATH
-RUN conda install -c conda-forge dask distributed drmaa nomkl pytest mock ipython pip psutil 
+RUN conda install -c conda-forge dask distributed nomkl pytest mock ipython pip psutil
+RUN pip install drmaa
 RUN pip install git+https://github.com/dask/distributed.git --upgrade
 
 COPY ./setup-slave.sh /

--- a/dask_drmaa/core.py
+++ b/dask_drmaa/core.py
@@ -31,8 +31,8 @@ TASK_ID = "$SGE_TASK_ID$SLURM_ARRAY_TASK_ID$LSB_JOBINDEX"
 
 default_template = {
     'jobName': 'dask-worker',
-    'outputPath': ':%s/out' % os.getcwd(),
-    'errorPath': ':%s/err' % os.getcwd(),
+    'outputPath': ':%s/worker.$JOB_ID.$drmaa_incr_ph$.out' % os.getcwd(),
+    'errorPath': ':%s/worker.$JOB_ID.$drmaa_incr_ph$.err' % os.getcwd(),
     'workingDirectory': os.getcwd(),
     'nativeSpecification': '',
     'args': []

--- a/dask_drmaa/core.py
+++ b/dask_drmaa/core.py
@@ -25,6 +25,9 @@ def get_session():
 
 worker_bin_path = os.path.join(sys.exec_prefix, 'bin', 'dask-worker')
 
+# All JOB_ID and TASK_ID environment variables
+JOB_ID = "$JOB_ID$SLURM_JOB_ID$LSB_JOBID"
+TASK_ID = "$SGE_TASK_ID$SLURM_ARRAY_TASK_ID$LSB_JOBINDEX"
 
 default_template = {
     'jobName': 'dask-worker',
@@ -38,8 +41,8 @@ default_template = {
 
 script_template = ("""
 #!/bin/bash
-%s $1 --name $JOB_ID.$SGE_TASK_ID "${@:2}"
-""" % worker_bin_path).strip()
+%s $1 --name %s.%s "${@:2}"
+""" % (worker_bin_path, JOB_ID, TASK_ID)).strip()
 
 
 class DRMAACluster(object):

--- a/dask_drmaa/core.py
+++ b/dask_drmaa/core.py
@@ -6,6 +6,7 @@ import tempfile
 
 import drmaa
 from toolz import merge
+from tornado import gen
 from tornado.ioloop import PeriodicCallback
 
 from distributed import LocalCluster
@@ -82,7 +83,7 @@ class DRMAACluster(object):
         """
         self.hostname = hostname or socket.gethostname()
         logger.info("Start local scheduler at %s", self.hostname)
-        self.local_cluster = LocalCluster(n_workers=0, **kwargs)
+        self.local_cluster = LocalCluster(n_workers=0, ip='', **kwargs)
 
         if script is None:
             self.script = tempfile.mktemp(suffix='sh',
@@ -106,13 +107,17 @@ class DRMAACluster(object):
 
         self.workers = {}  # {job-id: {'resource': quanitty}}
 
+    @gen.coroutine
+    def _start(self):
+        pass
+
     @property
     def scheduler(self):
         return self.local_cluster.scheduler
 
     @property
     def scheduler_address(self):
-        return '%s:%d' % (self.hostname, self.scheduler.port)
+        return self.scheduler.address
 
     def create_job_template(self, **kwargs):
         template = self.template.copy()

--- a/dask_drmaa/core.py
+++ b/dask_drmaa/core.py
@@ -86,11 +86,18 @@ class DRMAACluster(object):
         self.local_cluster = LocalCluster(n_workers=0, ip='', **kwargs)
 
         if script is None:
-            self.script = tempfile.mktemp(suffix='sh',
-                                          prefix='dask-worker-script',
-                                          dir=os.path.curdir)
-            with open(self.script, 'wt') as f:
+            fn = tempfile.mktemp(suffix='sh',
+                                 prefix='dask-worker-script',
+                                 dir=os.path.curdir)
+            self.script = fn
+
+            with open(fn, 'wt') as f:
                 f.write(script_template)
+
+            @atexit.register
+            def remove_script():
+                if os.path.exists(fn):
+                    os.remove(fn)
 
             os.chmod(self.script, 0o777)
 

--- a/dask_drmaa/tests/test_core.py
+++ b/dask_drmaa/tests/test_core.py
@@ -1,3 +1,4 @@
+import os
 from time import sleep, time
 
 import pytest
@@ -23,6 +24,8 @@ def test_simple(loop):
 
             assert not cluster.workers
 
+    assert not os.path.exists(cluster.script)
+
 
 def test_str(loop):
     with DRMAACluster(scheduler_port=0) as cluster:
@@ -34,16 +37,16 @@ def test_str(loop):
         1 + 1
 
 
-@pytest.mark.xfail(reason="Can't use job name environment variable as arg")
 def test_job_name_as_name(loop):
     with DRMAACluster(scheduler_port=0) as cluster:
         cluster.start_workers(2)
-        while len(cluster.scheduler.workers) < 1:
+        while len(cluster.scheduler.workers) < 2:
             sleep(0.1)
-            names = {cluster.scheduler.worker_info[w]['name']
-                     for w in cluster.scheduler.workers}
 
-            assert names == set(cluster.workers)
+        names = {cluster.scheduler.worker_info[w]['name']
+                 for w in cluster.scheduler.workers}
+
+        assert names == set(cluster.workers)
 
 
 def test_multiple_overlapping_clusters(loop):


### PR DESCRIPTION
This allows for a few things:

1.  Users can customize this script to their liking, introducing various
    environment variables as they see fit.

2.  We get to use DRMAA/SGE environment variables within this script
    See https://github.com/dask/dask-drmaa/issues/14

Problems
-------

I can't seem to find an environment variable for job/task ID that is DRMAA-generic.  Does this exist?  The solution so far uses SGE-specific terms, which we probably shouldn't merge.  cc @davidr