### PR TITLE
Add a basic manifest to aid in packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include LICENSE.txt
+include README.rst
+
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]


### PR DESCRIPTION
Make sure the LICENSE and README are included. Also ensure any compiled Python code is not included.