### PR TITLE
Tweak the `entry_points` format in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,9 @@ setup(name='dask-drmaa',
       install_requires=list(open('requirements.txt').read().strip().split('\n')),
       long_description=(open('README.rst').read() if exists('README.rst')
                         else ''),
-      entry_points='''
-      [console_scripts]
-      dask-drmaa=dask_drmaa.cli.dask_drmaa:go
-      ''',
+      entry_points={
+          'console_scripts': [
+              'dask-drmaa=dask_drmaa.cli.dask_drmaa:go',
+          ],
+      },
       zip_safe=False)


### PR DESCRIPTION
Makes the `entry_points` section, `console_scripts`, a dictionary instead of embedded in a string. Makes it a little easier to parse using external programs.