### PR TITLE
Package the requirements.txt file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,7 @@
 include LICENSE.txt
 include README.rst
 
+include requirements.txt
+
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]


### PR DESCRIPTION
This is needed by `setup.py` to determine the requirements of the package. So this definitely needs to land in the `sdist` or any other deployed product.