### PR TITLE
Fix flakiness in `test_stop_workers_politely`

### DIFF
--- a/dask_drmaa/tests/test_core.py
+++ b/dask_drmaa/tests/test_core.py
@@ -130,6 +130,9 @@ def test_stop_workers_politely(loop):
             a, b = cluster.workers
             cluster.stop_workers(a)
 
+            while len(client.ncores()) != 1:
+                sleep(0.1)
+
             data = client.gather(futures)
             assert data == list(range(10))
 


### PR DESCRIPTION
Fixes https://github.com/dask/dask-drmaa/issues/42

The `test_stop_workers_politely` test has been a bit flaky. Given the test is trying to shutdown a worker and compute results at the same time, this seems like part of the problem. To try and fix this, wait until the worker is shutdown completely before trying to retrieve results. Otherwise it seems to have issues.