### PR TITLE
Tornado 5 fix

### DIFF
--- a/dask_drmaa/core.py
+++ b/dask_drmaa/core.py
@@ -9,11 +9,10 @@ import tempfile
 import drmaa
 from toolz import merge
 from tornado import gen
-from tornado.ioloop import PeriodicCallback
 
 from distributed import LocalCluster
 from distributed.utils import log_errors, ignoring
-from distributed.protocol.pickle import dumps
+from distributed.utils import PeriodicCallback
 
 logger = logging.getLogger(__name__)
 

--- a/dask_drmaa/core.py
+++ b/dask_drmaa/core.py
@@ -142,8 +142,7 @@ class DRMAACluster(object):
                               template or {})
 
         self._cleanup_callback = PeriodicCallback(callback=self.cleanup_closed_workers,
-                                                  callback_time=cleanup_interval,
-                                                  io_loop=self.scheduler.loop)
+                                                  callback_time=cleanup_interval)
         self._cleanup_callback.start()
 
         self.workers = {}  # {job-id: WorkerSpec}

--- a/env.yml
+++ b/env.yml
@@ -1,7 +1,7 @@
 name: drmaa
 dependencies:
   - dask
-  - distributed
+  - distributed>=1.20.0
   - ipython
   - drmaa
   - python=3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 dask
-distributed
+distributed >= 1.20.0
 drmaa
 click


### PR DESCRIPTION
It looks like `io_loop` is not a a parameter of PeriodicCallback in Tornado 5, which makes master fail (see a build on my [fork](https://travis-ci.org/lesteve/dask-drmaa/builds/351210528). I am guessing Tornado 5 is picked up by pip from `pip install https://github.com/dask/distributed.git`. It is a new problem since Tornado 5 has been released a few days ago (March 5th according to https://pypi.python.org/pypi/tornado).

Not sure what the policy is for Tornado 4 vs Tornado 5. Do you want to support both? I guess the Python 2.7 build could use Tornado 4 and the 3.6 one use Tornado if that is the case.