### PR TITLE
Readd io_loop to PeriodicCallback

### DIFF
--- a/dask_drmaa/core.py
+++ b/dask_drmaa/core.py
@@ -163,7 +163,8 @@ class DRMAACluster(object):
                               template or {})
 
         self._cleanup_callback = PeriodicCallback(callback=self.cleanup_closed_workers,
-                                                  callback_time=cleanup_interval)
+                                                  callback_time=cleanup_interval,
+                                                  io_loop=self.scheduler.loop)
         self._cleanup_callback.start()
 
         self.workers = {}  # {job-id: WorkerSpec}


### PR DESCRIPTION
Appears we missed getting `io_loop` added back to `PeriodicCallback` in PR ( https://github.com/dask/dask-drmaa/pull/61 ) (sorry for missing that). As a result, we can get hangs in some cases when trying to start the `dask-drmaa` cluster. This readds the `io_loop` argument, which should fix that issue.

cc @mrocklin @lesteve