### PR TITLE
Compatibility fixes with distributed 1.21.3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,8 +52,7 @@ Testing
 
 This repository contains a Docker-compose testing harness for a Son of Grid
 Engine cluster with a master and two slaves.  You can initialize this system
-as follows (for Windows, make sure to remove any carriage returns from all
-`*.sh` shell scripts and `docker-compose.yml`):
+as follows:
 
 .. code-block:: bash
 

--- a/README.rst
+++ b/README.rst
@@ -51,8 +51,9 @@ Testing
 -------
 
 This repository contains a Docker-compose testing harness for a Son of Grid
-Engine cluster with a master and two slaves.   You can initialize this system
-as follows
+Engine cluster with a master and two slaves.  You can initialize this system
+as follows (for Windows, make sure to remove any carriage returns from all
+`*.sh` shell scripts and `docker-compose.yml`):
 
 .. code-block:: bash
 

--- a/dask_drmaa/adaptive.py
+++ b/dask_drmaa/adaptive.py
@@ -6,6 +6,7 @@ import warnings
 from distributed import Scheduler
 from distributed.utils import log_errors
 from distributed.deploy import adaptive
+from six import string_types
 from tornado import gen
 
 from .core import get_session
@@ -79,7 +80,7 @@ class Adaptive(adaptive.Adaptive):
         memory = []
         if self.scheduler.unrunnable:
             for task in self.scheduler.unrunnable:
-                if isinstance(task, basestring):
+                if isinstance(task, string_types):
                     # Backwards compatibility for distributed pre-1.21.0
                     key = task
                     prefix = key
@@ -118,4 +119,3 @@ class Adaptive(adaptive.Adaptive):
             # Diverges from distributed.Adaptive here:
             # ref c51a15a35a8a64c21c1182bfd9209cb6b7d95380
         raise gen.Return(result)
-

--- a/dask_drmaa/adaptive.py
+++ b/dask_drmaa/adaptive.py
@@ -78,10 +78,20 @@ class Adaptive(adaptive.Adaptive):
         kwargs = {'n': max(instances, len(self.get_busy_workers()))}
         memory = []
         if self.scheduler.unrunnable:
-            for key in self.scheduler.unrunnable:
+            for task in self.scheduler.unrunnable:
+                if isinstance(task, basestring):
+                    # Backwards compatibility for distributed pre-1.21.0
+                    key = task
+                    prefix = key
+                else:
+                    # In distributed==1.21.0, the scheduler now stores TaskState objects
+                    # instead of string keys in its task collections:
+                    # https://github.com/dask/distributed/pull/1594
+                    key = task.key
+                    prefix = task.prefix
                 duration = 0
                 memory = []
-                duration += self.scheduler.task_duration.get(key, 0.1)
+                duration += self.scheduler.task_duration.get(prefix, 0.1)
 
                 if key in self.scheduler.resource_restrictions:
                     m = self.scheduler.resource_restrictions[key].get('memory')

--- a/dask_drmaa/adaptive.py
+++ b/dask_drmaa/adaptive.py
@@ -118,4 +118,5 @@ class Adaptive(adaptive.Adaptive):
                 logger.info("Retiring workers {}".format(result))
             # Diverges from distributed.Adaptive here:
             # ref c51a15a35a8a64c21c1182bfd9209cb6b7d95380
+            # TODO: can this be reconciled back to base class implementation?
         raise gen.Return(result)

--- a/dask_drmaa/adaptive.py
+++ b/dask_drmaa/adaptive.py
@@ -6,7 +6,6 @@ import warnings
 from distributed import Scheduler
 from distributed.utils import log_errors
 from distributed.deploy import adaptive
-from six import string_types
 from tornado import gen
 
 from .core import get_session
@@ -80,16 +79,8 @@ class Adaptive(adaptive.Adaptive):
         memory = []
         if self.scheduler.unrunnable:
             for task in self.scheduler.unrunnable:
-                if isinstance(task, string_types):
-                    # Backwards compatibility for distributed pre-1.21.0
-                    key = task
-                    prefix = key
-                else:
-                    # In distributed==1.21.0, the scheduler now stores TaskState objects
-                    # instead of string keys in its task collections:
-                    # https://github.com/dask/distributed/pull/1594
-                    key = task.key
-                    prefix = task.prefix
+                key = task.key
+                prefix = task.prefix
                 duration = 0
                 memory = []
                 duration += self.scheduler.task_duration.get(prefix, 0.1)

--- a/dask_drmaa/sge.py
+++ b/dask_drmaa/sge.py
@@ -42,6 +42,7 @@ class SGECluster(DRMAACluster):
         if memory:
             args = args + ['--memory-limit', str(memory * (1 - memory_fraction))]
             args = args + ['--resources', 'memory=%f' % (memory * memory_fraction)]
+            # h_vmem is SGE-specific
             ns += ' -l h_vmem=%dG' % int(memory / 1e9) # / cpus
         if cpus:
             args = args + ['--nprocs', '1', '--nthreads', str(cpus)]

--- a/dask_drmaa/tests/test_adaptive.py
+++ b/dask_drmaa/tests/test_adaptive.py
@@ -8,8 +8,6 @@ from dask_drmaa.adaptive import Adaptive
 from distributed import Client
 from distributed.utils_test import loop, inc, slowinc
 
-
-@pytest.mark.skip(reason="currently times out for an unknown reason")
 def test_adaptive_memory(loop):
     with SGECluster(scheduler_port=0, cleanup_interval=100) as cluster:
         adapt = Adaptive(cluster, cluster.scheduler)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ dask
 distributed >= 1.20.0
 drmaa
 click
+six

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 dask
-distributed >= 1.20.0
+distributed >= 1.21.0
 drmaa
 click
-six


### PR DESCRIPTION
- Support passing kwargs to `distributed.Adaptive.__init__`, which now includes arguments like `minimum` and `maximum` [number of workers].
- Add an optional `workers` argument to `_retire_workers()` to match https://github.com/dask/distributed/pull/1797 (currently throws a `TypeError`)