### PR TITLE
Add Torque job info

### DIFF
--- a/dask_drmaa/core.py
+++ b/dask_drmaa/core.py
@@ -35,6 +35,7 @@ worker_bin_path = os.path.join(sys.exec_prefix, 'bin', 'dask-worker')
 
 # All JOB_ID and TASK_ID environment variables
 _drm_info = drmaa.Session().drmsInfo
+
 if "SLURM" in _drm_info:
     JOB_PARAM = "%j"
     JOB_ID = "$SLURM_JOB_ID"
@@ -47,6 +48,10 @@ elif "GE" in _drm_info:
     JOB_PARAM = "$JOB_ID"
     JOB_ID = "$JOB_ID"
     TASK_ID = "$SGE_TASK_ID"
+elif _drm_info == "Torque":
+    JOB_PARAM = "$PBS_JOBID"
+    JOB_ID = "$PBS_JOBID"
+    TASK_ID = "$PBS_TASKNUM"
 else:
     JOB_PARAM = ""
     JOB_ID = ""

--- a/dask_drmaa/core.py
+++ b/dask_drmaa/core.py
@@ -34,7 +34,9 @@ WorkerSpec = namedtuple('WorkerSpec',
 worker_bin_path = os.path.join(sys.exec_prefix, 'bin', 'dask-worker')
 
 # All JOB_ID and TASK_ID environment variables
-_drm_info = drmaa.Session().drmsInfo
+_session = drmaa.Session()
+_drm_info = _session.drmsInfo
+_drmaa_implementation = _session.drmaaImplementation
 
 if "SLURM" in _drm_info:
     JOB_PARAM = "%j"
@@ -48,7 +50,7 @@ elif "GE" in _drm_info:
     JOB_PARAM = "$JOB_ID"
     JOB_ID = "$JOB_ID"
     TASK_ID = "$SGE_TASK_ID"
-elif _drm_info == "Torque":
+elif "Torque" == _drm_info or "PBS" in _drmaa_implementation:
     JOB_PARAM = "$PBS_JOBID"
     JOB_ID = "$PBS_JOBID"
     TASK_ID = "$PBS_TASKNUM"


### PR DESCRIPTION
This makes `dask-drmaa` work on `PBS/Torque`

I'm not sure what exactly the difference between JOB_PARAM and JOB_ID should be.

Here are all PBS related env variables:
```
PBS_ENVIRONMENT=PBS_INTERACTIVE
PBS_GPUFILE=/var/spool/torque/aux//7641024.hpc-main3.cm.clustergpu
PBS_JOBCOOKIE=D57B25C527004153B093AC7B41FC9CA8
PBS_JOBID=7641024.hpc-main3.cm.cluster
PBS_JOBNAME=STDIN
PBS_MICFILE=/var/spool/torque/aux//7641024.hpc-main3.cm.clustermic
PBS_MOMPORT=15003
PBS_NODEFILE=/var/spool/torque/aux//7641024.hpc-main3.cm.cluster
PBS_NODENUM=0
PBS_NP=1
PBS_NUM_NODES=1
PBS_NUM_PPN=1
PBS_O_HOME=/home/mnoethe
PBS_O_HOST=hpc-gw3.cm.cluster
PBS_O_LANG=en_US.UTF-8
PBS_O_LOGNAME=mnoethe
PBS_O_MAIL=/var/spool/mail/mnoethe
PBS_O_PATH=/home/mnoethe/.conda/envs/dask/bin:/sl6/sw/python/anaconda36/bin:/sl6/sw/cmake/3.5.1/bin:/sl6/sw/gcc/5.1.0/rtf/bin:/sl6/sw/java/jdk1.8.0_112/bin:/home/mnoethe/.local/bin:/sl6/sw/maven/3.2.1/bin:/sl6/sw/vim/7.4/bin:/usr/lib64/qt-3.3/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/home/mnoethe/bin
PBS_O_QUEUE=batch
PBS_O_SERVER=hpc-main3.cm.cluster
PBS_O_SHELL=/bin/bash
PBS_O_WORKDIR=/home/mnoethe/dask-drmaa
PBS_QUEUE=short
PBS_TASKNUM=1
PBS_VERSION=TORQUE-4.2.8
PBS_VNODENUM=0
PBS_WALLTIME=7200
```