### PR TITLE
Use stable distributed for CI

### DIFF
--- a/Dockerfile-master
+++ b/Dockerfile-master
@@ -11,7 +11,6 @@ RUN curl -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-L
 ENV PATH /opt/anaconda/bin:$PATH
 RUN conda install -n root conda=4.4.11 && conda clean -tipy
 RUN conda install -c conda-forge dask distributed blas pytest mock ipython pip psutil python-drmaa && conda clean -tipy
-RUN pip install --no-cache-dir git+https://github.com/dask/distributed.git --upgrade
 
 COPY ./*.sh /
 COPY ./*.txt /

--- a/Dockerfile-master
+++ b/Dockerfile-master
@@ -10,8 +10,7 @@ RUN curl -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-L
     rm -f miniconda.sh
 ENV PATH /opt/anaconda/bin:$PATH
 RUN conda install -n root conda=4.4.11 && conda clean -tipy
-RUN conda install -c conda-forge dask distributed blas pytest mock ipython pip psutil && conda clean -tipy
-RUN pip install --no-cache-dir drmaa
+RUN conda install -c conda-forge dask distributed blas pytest mock ipython pip psutil python-drmaa && conda clean -tipy
 RUN pip install --no-cache-dir git+https://github.com/dask/distributed.git --upgrade
 
 COPY ./*.sh /

--- a/Dockerfile-slave
+++ b/Dockerfile-slave
@@ -10,8 +10,7 @@ RUN curl -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-L
     rm -f miniconda.sh
 ENV PATH /opt/anaconda/bin:$PATH
 RUN conda install -n root conda=4.4.11 && conda clean -tipy
-RUN conda install -c conda-forge dask distributed blas pytest mock ipython pip psutil && conda clean -tipy
-RUN pip install --no-cache-dir drmaa
+RUN conda install -c conda-forge dask distributed blas pytest mock ipython pip psutil python-drmaa && conda clean -tipy
 RUN pip install --no-cache-dir git+https://github.com/dask/distributed.git --upgrade
 
 COPY ./setup-slave.sh /

--- a/Dockerfile-slave
+++ b/Dockerfile-slave
@@ -11,7 +11,6 @@ RUN curl -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-L
 ENV PATH /opt/anaconda/bin:$PATH
 RUN conda install -n root conda=4.4.11 && conda clean -tipy
 RUN conda install -c conda-forge dask distributed blas pytest mock ipython pip psutil python-drmaa && conda clean -tipy
-RUN pip install --no-cache-dir git+https://github.com/dask/distributed.git --upgrade
 
 COPY ./setup-slave.sh /
 COPY ./run-slave.sh /


### PR DESCRIPTION
Switch to using the stable version of distributed for now. There are some config changes in progress in dask and distributed that don't really affect us, but don't work correctly without using dev versions of both and we have only been using dev versions of distributed. Should help to test against stable versions of both if we need to make another release too.