### PR TITLE
Call `dask-worker` through Python executable

### DIFF
--- a/dask_drmaa/core.py
+++ b/dask_drmaa/core.py
@@ -31,7 +31,10 @@ WorkerSpec = namedtuple('WorkerSpec',
                         ('job_id', 'kwargs', 'stdout', 'stderr'))
 
 
-worker_bin_path = os.path.join(sys.exec_prefix, 'bin', 'dask-worker')
+worker_bin_path = (
+    '%(python)s -m distributed.cli.dask_worker'
+    % dict(python=sys.executable)
+)
 
 # All JOB_ID and TASK_ID environment variables
 _drm_info = get_session().drmsInfo


### PR DESCRIPTION
Fixes https://github.com/dask/dask-drmaa/issues/88
Alternative to PR ( https://github.com/dask/dask-drmaa/pull/89 )

To ensure that the right `dask-worker` executable is found, make use of `python -m` to search for and run the `distributed.cli.dask_worker` module. This is robust to different install locations or directory layouts as it doesn't care where `dask-worker` actually is. Instead it only cares where `distributed` is installed, which has to be accessible from the same `python` running `dask-drmaa` (as it is a dependency). From there it can simply rely on `python` to figure out where `dask_worker` lives so that it can run it.

cc @MaxNoe