### PR TITLE
Mark `test_stop_single_worker` as a known failure

### DIFF
--- a/dask_drmaa/tests/test_core.py
+++ b/dask_drmaa/tests/test_core.py
@@ -106,6 +106,10 @@ def test_multiple_overlapping_clusters(loop):
                     assert future_2.result() == 3
 
 
+@pytest.mark.skip(
+    reason="Failing worker cleanup possibly due to upstream change.\n"
+    "xref: https://github.com/dask/dask-drmaa/issues/93"
+)
 def test_stop_single_worker(loop):
     with DRMAACluster(scheduler_port=0) as cluster:
         with Client(cluster, loop=loop) as client:


### PR DESCRIPTION
This test has been flaky historically. However it appears to now be reliably failing on both Python 2 & 3. Would be good to fix it once the cause is understood. Though it is not a critical failure, so we can tolerate marking it as a failure and tracking for now. There are other changes planned (e.g. updating worker startup and shutdown) that may end up fixing it.

xref: https://github.com/dask/dask-drmaa/issues/93